### PR TITLE
Make CTok accept strings as well as bytes

### DIFF
--- a/ctok.c
+++ b/ctok.c
@@ -49,16 +49,12 @@ static int
 CTok_init(CTokObject *self, PyObject *args, PyObject *kwds)
 {
     static char *kwlist[] = {"input", NULL};
-    PyObject *input;
+    Py_buffer buffer;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "S", kwlist, &input))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s*", kwlist, &buffer))
         return -1;
 
-    char *bytes = PyBytes_AsString(input);
-    if (bytes == NULL)
-        return -1;
-
-    self->tok = PyTokenizer_FromString(bytes, 0);
+    self->tok = PyTokenizer_FromString(buffer.buf, 0);
     if (self->tok == NULL)
         return -1;
 

--- a/demo.py
+++ b/demo.py
@@ -3,12 +3,12 @@ from token import *
 
 import ctok
 
-tok = ctok.CTok(b"(hello+world)")
+tok = ctok.CTok("(hello+world)")
 for token in tok:
     print(token)
 
 print("Raw:")
-tok = ctok.CTok(b"(hello+world)")
+tok = ctok.CTok("(hello+world)")
 while True:
     token = tok.get_raw()
     print(token)

--- a/test_ctok.py
+++ b/test_ctok.py
@@ -16,6 +16,17 @@ def test_basic():
         (RPAR, b')', (1, 12), (1, 13)),
     ]
 
+def test_with_str():
+    input = "(привет+мир)"
+    tokens = list(ctok.CTok(input))
+    assert tokens == [
+        (LPAR, b'(', (1, 0), (1, 1)),
+        (NAME, 'привет'.encode("utf-8"), (1, 1), (1, 13)),
+        (PLUS, b'+', (1, 13), (1, 14)),
+        (NAME, 'мир'.encode("utf-8"), (1, 14), (1, 20)),
+        (RPAR, b')', (1, 20), (1, 21)),
+    ]
+
 def test_indent():
     input = b"if 1:\n  pass\npass"
     tokens = list(ctok.CTok(input))


### PR DESCRIPTION
Now CTok accepts `str` as well as `bytes` objects as code. It also seems to work fine with unicode source (as shown in the test).
Maybe it would make sense to add an alternative iterator that would yield `str` instead of `bytes`.